### PR TITLE
Add Bedrock's bone meal functionality

### DIFF
--- a/datapacks/ocw-stuff/data/nincodedo/advancements/interaction/small_flowers/bone_meal_on_flower.json
+++ b/datapacks/ocw-stuff/data/nincodedo/advancements/interaction/small_flowers/bone_meal_on_flower.json
@@ -1,0 +1,29 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:player_interacted_with_entity",
+      "conditions": {
+        "item": {
+          "items": [
+            "minecraft:bone_meal"
+          ],
+          "count": {
+            "min": 1
+          }
+        },
+        "entity": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "nbt": "{Tags:[\"small_flower_interaction\"]}"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "nincodedo:interaction/small_flowers/use_bone_meal"
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/advancements/interaction/small_flowers/holding_bone_meal.json
+++ b/datapacks/ocw-stuff/data/nincodedo/advancements/interaction/small_flowers/holding_bone_meal.json
@@ -1,0 +1,32 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:tick",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "type": "minecraft:player",
+              "nbt": "{SelectedItem:{id:\"minecraft:bone_meal\"}}"
+            }
+          },
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "nbt": "{Tags:[\"holdbonemeal\"]}"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "nincodedo:interaction/small_flowers/add_tag"
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/advancements/interaction/small_flowers/not_holding_bone_meal.json
+++ b/datapacks/ocw-stuff/data/nincodedo/advancements/interaction/small_flowers/not_holding_bone_meal.json
@@ -1,0 +1,32 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:tick",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "type": "minecraft:player",
+              "nbt": "{Tags:[\"holdbonemeal\"]}"
+            }
+          },
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:entity_properties",
+              "entity": "this",
+              "predicate": {
+                "nbt": "{SelectedItem:{id:\"minecraft:bone_meal\"}}"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "nincodedo:interaction/small_flowers/remove_tag"
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/advancements/interaction/small_flowers/remove_interaction.json
+++ b/datapacks/ocw-stuff/data/nincodedo/advancements/interaction/small_flowers/remove_interaction.json
@@ -1,0 +1,23 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:tick",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": "this",
+              "score": "lookingatsmallflower"
+            },
+            "range": 0
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "nincodedo:interaction/small_flowers/remove_interaction"
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/advancements/interaction/small_flowers/spawn_interaction.json
+++ b/datapacks/ocw-stuff/data/nincodedo/advancements/interaction/small_flowers/spawn_interaction.json
@@ -1,0 +1,25 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:tick",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": "this",
+              "score": "lookingatsmallflower"
+            },
+            "range": {
+              "min": 1
+            }
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "nincodedo:interaction/small_flowers/spawn_interaction"
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/advancements/interaction/sugar_cane/bone_meal_on_sugar_cane.json
+++ b/datapacks/ocw-stuff/data/nincodedo/advancements/interaction/sugar_cane/bone_meal_on_sugar_cane.json
@@ -1,0 +1,29 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:player_interacted_with_entity",
+      "conditions": {
+        "item": {
+          "items": [
+            "minecraft:bone_meal"
+          ],
+          "count": {
+            "min": 1
+          }
+        },
+        "entity": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "nbt": "{Tags:[\"sugar_cane_interaction\"]}"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "nincodedo:interaction/sugar_cane/use_bone_meal"
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/advancements/interaction/sugar_cane/remove_interaction.json
+++ b/datapacks/ocw-stuff/data/nincodedo/advancements/interaction/sugar_cane/remove_interaction.json
@@ -1,0 +1,23 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:tick",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": "this",
+              "score": "lookingatsugarcane"
+            },
+            "range": 0
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "nincodedo:interaction/sugar_cane/remove_interaction"
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/advancements/interaction/sugar_cane/spawn_interaction.json
+++ b/datapacks/ocw-stuff/data/nincodedo/advancements/interaction/sugar_cane/spawn_interaction.json
@@ -1,0 +1,25 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:tick",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:value_check",
+            "value": {
+              "type": "minecraft:score",
+              "target": "this",
+              "score": "lookingatsugarcane"
+            },
+            "range": {
+              "min": 1
+            }
+          }
+        ]
+      }
+    }
+  },
+  "rewards": {
+    "function": "nincodedo:interaction/sugar_cane/spawn_interaction"
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/functions/interaction/small_flowers/add_tag.mcfunction
+++ b/datapacks/ocw-stuff/data/nincodedo/functions/interaction/small_flowers/add_tag.mcfunction
@@ -1,0 +1,2 @@
+tag @s add holdbonemeal
+advancement revoke @s only nincodedo:interaction/small_flowers/not_holding_bone_meal

--- a/datapacks/ocw-stuff/data/nincodedo/functions/interaction/small_flowers/remove_interaction.mcfunction
+++ b/datapacks/ocw-stuff/data/nincodedo/functions/interaction/small_flowers/remove_interaction.mcfunction
@@ -1,0 +1,2 @@
+advancement revoke @s only nincodedo:interaction/small_flowers/spawn_interaction
+kill @e[tag=small_flower_interaction,distance=..5,sort=nearest,limit=3]

--- a/datapacks/ocw-stuff/data/nincodedo/functions/interaction/small_flowers/remove_tag.mcfunction
+++ b/datapacks/ocw-stuff/data/nincodedo/functions/interaction/small_flowers/remove_tag.mcfunction
@@ -1,0 +1,3 @@
+tag @s remove holdbonemeal
+advancement revoke @s only nincodedo:interaction/small_flowers/holding_bone_meal
+scoreboard players set @s lookingatsmallflower 0

--- a/datapacks/ocw-stuff/data/nincodedo/functions/interaction/small_flowers/remove_tag.mcfunction
+++ b/datapacks/ocw-stuff/data/nincodedo/functions/interaction/small_flowers/remove_tag.mcfunction
@@ -1,3 +1,4 @@
 tag @s remove holdbonemeal
 advancement revoke @s only nincodedo:interaction/small_flowers/holding_bone_meal
 scoreboard players set @s lookingatsmallflower 0
+scoreboard players set @s lookingatsugarcane 0

--- a/datapacks/ocw-stuff/data/nincodedo/functions/interaction/small_flowers/spawn_interaction.mcfunction
+++ b/datapacks/ocw-stuff/data/nincodedo/functions/interaction/small_flowers/spawn_interaction.mcfunction
@@ -1,0 +1,4 @@
+execute anchored eyes positioned ^ ^ ^1 if block ~ ~ ~ #minecraft:small_flowers run summon minecraft:interaction ~ ~ ~ {width:1.0f,height:1.0f,response:true,Tags:["small_flower_interaction"]}
+execute anchored eyes positioned ^ ^ ^2 if block ~ ~ ~ #minecraft:small_flowers run summon minecraft:interaction ~ ~ ~ {width:1.0f,height:1.0f,response:true,Tags:["small_flower_interaction"]}
+execute anchored eyes positioned ^ ^ ^3 if block ~ ~ ~ #minecraft:small_flowers run summon minecraft:interaction ~ ~ ~ {width:1.0f,height:1.0f,response:true,Tags:["small_flower_interaction"]}
+advancement revoke @s only nincodedo:interaction/small_flowers/remove_interaction

--- a/datapacks/ocw-stuff/data/nincodedo/functions/interaction/small_flowers/use_bone_meal.mcfunction
+++ b/datapacks/ocw-stuff/data/nincodedo/functions/interaction/small_flowers/use_bone_meal.mcfunction
@@ -1,0 +1,24 @@
+clear @s minecraft:bone_meal 1
+execute at @e[tag=small_flower_interaction,sort=nearest,limit=1] run summon minecraft:marker ~ ~ ~ {Tags:["place_flower"]}
+execute at @e[tag=small_flower_interaction,sort=nearest,limit=1] run summon minecraft:marker ~ ~ ~ {Tags:["place_flower"]}
+execute at @e[tag=small_flower_interaction,sort=nearest,limit=1] run summon minecraft:marker ~ ~ ~ {Tags:["place_flower"]}
+execute at @e[tag=small_flower_interaction,sort=nearest,limit=1] run spreadplayers ~ ~ 1 3.5 false @e[tag=place_flower,sort=nearest,limit=3]
+
+execute at @e[tag=small_flower_interaction,sort=nearest,limit=1] if block ~ ~ ~ minecraft:dandelion positioned as @e[tag=place_flower,sort=nearest,limit=3] positioned over motion_blocking_no_leaves run setblock ~ ~ ~ minecraft:dandelion
+execute at @e[tag=small_flower_interaction,sort=nearest,limit=1] if block ~ ~ ~ minecraft:poppy positioned as @e[tag=place_flower,sort=nearest,limit=3] positioned over motion_blocking_no_leaves run setblock ~ ~ ~ minecraft:poppy
+execute at @e[tag=small_flower_interaction,sort=nearest,limit=1] if block ~ ~ ~ minecraft:blue_orchid positioned as @e[tag=place_flower,sort=nearest,limit=3] positioned over motion_blocking_no_leaves run setblock ~ ~ ~ minecraft:blue_orchid
+execute at @e[tag=small_flower_interaction,sort=nearest,limit=1] if block ~ ~ ~ minecraft:allium positioned as @e[tag=place_flower,sort=nearest,limit=3] positioned over motion_blocking_no_leaves run setblock ~ ~ ~ minecraft:allium
+execute at @e[tag=small_flower_interaction,sort=nearest,limit=1] if block ~ ~ ~ minecraft:azure_bluet positioned as @e[tag=place_flower,sort=nearest,limit=3] positioned over motion_blocking_no_leaves run setblock ~ ~ ~ minecraft:azure_bluet
+execute at @e[tag=small_flower_interaction,sort=nearest,limit=1] if block ~ ~ ~ minecraft:red_tulip positioned as @e[tag=place_flower,sort=nearest,limit=3] positioned over motion_blocking_no_leaves run setblock ~ ~ ~ minecraft:red_tulip
+execute at @e[tag=small_flower_interaction,sort=nearest,limit=1] if block ~ ~ ~ minecraft:orange_tulip positioned as @e[tag=place_flower,sort=nearest,limit=3] positioned over motion_blocking_no_leaves run setblock ~ ~ ~ minecraft:orange_tulip
+execute at @e[tag=small_flower_interaction,sort=nearest,limit=1] if block ~ ~ ~ minecraft:white_tulip positioned as @e[tag=place_flower,sort=nearest,limit=3] positioned over motion_blocking_no_leaves run setblock ~ ~ ~ minecraft:white_tulip
+execute at @e[tag=small_flower_interaction,sort=nearest,limit=1] if block ~ ~ ~ minecraft:pink_tulip positioned as @e[tag=place_flower,sort=nearest,limit=3] positioned over motion_blocking_no_leaves run setblock ~ ~ ~ minecraft:pink_tulip
+execute at @e[tag=small_flower_interaction,sort=nearest,limit=1] if block ~ ~ ~ minecraft:oxeye_daisy positioned as @e[tag=place_flower,sort=nearest,limit=3] positioned over motion_blocking_no_leaves run setblock ~ ~ ~ minecraft:oxeye_daisy
+execute at @e[tag=small_flower_interaction,sort=nearest,limit=1] if block ~ ~ ~ minecraft:cornflower positioned as @e[tag=place_flower,sort=nearest,limit=3] positioned over motion_blocking_no_leaves run setblock ~ ~ ~ minecraft:cornflower
+execute at @e[tag=small_flower_interaction,sort=nearest,limit=1] if block ~ ~ ~ minecraft:lily_of_the_valley positioned as @e[tag=place_flower,sort=nearest,limit=3] positioned over motion_blocking_no_leaves run setblock ~ ~ ~ minecraft:lily_of_the_valley
+
+execute at @e[tag=small_flower_interaction,sort=nearest,limit=1] run particle minecraft:happy_villager ~ ~ ~ 2 0.25 2 1 150
+
+kill @e[tag=place_flower,distance=..8]
+
+advancement revoke @s only nincodedo:interaction/small_flowers/bone_meal_on_flower

--- a/datapacks/ocw-stuff/data/nincodedo/functions/interaction/sugar_cane/remove_interaction.mcfunction
+++ b/datapacks/ocw-stuff/data/nincodedo/functions/interaction/sugar_cane/remove_interaction.mcfunction
@@ -1,0 +1,2 @@
+advancement revoke @s only nincodedo:interaction/sugar_cane/spawn_interaction
+kill @e[tag=sugar_cane_interaction,distance=..5,sort=nearest,limit=3]

--- a/datapacks/ocw-stuff/data/nincodedo/functions/interaction/sugar_cane/spawn_interaction.mcfunction
+++ b/datapacks/ocw-stuff/data/nincodedo/functions/interaction/sugar_cane/spawn_interaction.mcfunction
@@ -1,0 +1,22 @@
+execute anchored eyes positioned ^ ^ ^1 if block ~ ~ ~ minecraft:sugar_cane run summon minecraft:marker ~ ~ ~ {Tags:["find_sugar_cane"]}
+execute anchored eyes positioned ^ ^ ^2 if block ~ ~ ~ minecraft:sugar_cane run summon minecraft:marker ~ ~ ~ {Tags:["find_sugar_cane"]}
+execute anchored eyes positioned ^ ^ ^3 if block ~ ~ ~ minecraft:sugar_cane run summon minecraft:marker ~ ~ ~ {Tags:["find_sugar_cane"]}
+
+execute store result score sc_x rhcdata run data get entity @e[tag=find_sugar_cane,sort=nearest,limit=1] Pos[0]
+execute store result score sc_y rhcdata run data get entity @e[tag=find_sugar_cane,sort=nearest,limit=1] Pos[1]
+execute store result score sc_z rhcdata run data get entity @e[tag=find_sugar_cane,sort=nearest,limit=1] Pos[2]
+
+execute store result storage nincodedo:storage PosX double 1 run scoreboard players get sc_x rhcdata
+execute store result storage nincodedo:storage PosY double 1 run scoreboard players get sc_y rhcdata
+execute store result storage nincodedo:storage PosZ double 1 run scoreboard players get sc_z rhcdata
+
+data modify entity @e[tag=find_sugar_cane,sort=nearest,limit=1] Pos[0] set from storage nincodedo:storage PosX
+data modify entity @e[tag=find_sugar_cane,sort=nearest,limit=1] Pos[1] set from storage nincodedo:storage PosY
+data modify entity @e[tag=find_sugar_cane,sort=nearest,limit=1] Pos[2] set from storage nincodedo:storage PosZ
+execute as @e[tag=find_sugar_cane] at @s run tp ~0.5 ~ ~0.5
+
+execute at @e[tag=find_sugar_cane,sort=nearest,limit=1] run summon minecraft:interaction ~ ~ ~ {width:1.0f,height:1.0f,response:true,Tags:["sugar_cane_interaction"]}
+
+kill @e[tag=find_sugar_cane,sort=nearest,limit=3,distance=..3]
+
+advancement revoke @s only nincodedo:interaction/sugar_cane/remove_interaction

--- a/datapacks/ocw-stuff/data/nincodedo/functions/interaction/sugar_cane/use_bone_meal.mcfunction
+++ b/datapacks/ocw-stuff/data/nincodedo/functions/interaction/sugar_cane/use_bone_meal.mcfunction
@@ -1,0 +1,14 @@
+scoreboard players reset @s sugarcaneheight
+execute at @e[tag=sugar_cane_interaction,sort=nearest,limit=1] if block ~ ~ ~ minecraft:sugar_cane run scoreboard players add @s sugarcaneheight 1
+execute at @e[tag=sugar_cane_interaction,sort=nearest,limit=1] if block ~ ~1 ~ minecraft:sugar_cane run scoreboard players add @s sugarcaneheight 1
+execute at @e[tag=sugar_cane_interaction,sort=nearest,limit=1] if block ~ ~2 ~ minecraft:sugar_cane run scoreboard players add @s sugarcaneheight 1
+execute at @e[tag=sugar_cane_interaction,sort=nearest,limit=1] if block ~ ~-1 ~ minecraft:sugar_cane run scoreboard players add @s sugarcaneheight 1
+execute at @e[tag=sugar_cane_interaction,sort=nearest,limit=1] if block ~ ~-2 ~ minecraft:sugar_cane run scoreboard players add @s sugarcaneheight 1
+
+execute if score @s sugarcaneheight matches 1..2 run clear @s minecraft:bone_meal 1
+execute if score @s sugarcaneheight matches 2 at @e[tag=sugar_cane_interaction,sort=nearest,limit=1] if block ~ ~1 ~ minecraft:sugar_cane run setblock ~ ~2 ~ minecraft:sugar_cane
+execute if score @s sugarcaneheight matches 1..2 at @e[tag=sugar_cane_interaction,sort=nearest,limit=1] unless block ~ ~1 ~ minecraft:sugar_cane run setblock ~ ~1 ~ minecraft:sugar_cane
+execute if score @s sugarcaneheight matches 1 at @e[tag=sugar_cane_interaction,sort=nearest,limit=1] unless block ~ ~2 ~ minecraft:sugar_cane run setblock ~ ~2 ~ minecraft:sugar_cane
+execute if score @s sugarcaneheight matches 1..2 at @e[tag=sugar_cane_interaction,sort=nearest,limit=1] run particle minecraft:happy_villager ~ ~.5 ~ 0.25 0.25 0.25 .75 9
+
+advancement revoke @s only nincodedo:interaction/sugar_cane/bone_meal_on_sugar_cane

--- a/datapacks/ocw-stuff/data/nincodedo/functions/load.mcfunction
+++ b/datapacks/ocw-stuff/data/nincodedo/functions/load.mcfunction
@@ -4,6 +4,7 @@ function nincodedo:items/load
 scoreboard objectives add advrewards dummy
 scoreboard objectives add bannerplz trigger
 scoreboard players enable @a bannerplz
+scoreboard objectives add lookingatsmallflower dummy
 execute store result score current_day rhcdata run time query day
 function nincodedo:setuplogbreakcount
 schedule function nincodedo:calculatelogbreak 10t

--- a/datapacks/ocw-stuff/data/nincodedo/functions/load.mcfunction
+++ b/datapacks/ocw-stuff/data/nincodedo/functions/load.mcfunction
@@ -5,6 +5,8 @@ scoreboard objectives add advrewards dummy
 scoreboard objectives add bannerplz trigger
 scoreboard players enable @a bannerplz
 scoreboard objectives add lookingatsmallflower dummy
+scoreboard objectives add lookingatsugarcane dummy
+scoreboard objectives add sugarcaneheight dummy
 execute store result score current_day rhcdata run time query day
 function nincodedo:setuplogbreakcount
 schedule function nincodedo:calculatelogbreak 10t

--- a/datapacks/ocw-stuff/data/nincodedo/functions/tick.mcfunction
+++ b/datapacks/ocw-stuff/data/nincodedo/functions/tick.mcfunction
@@ -2,3 +2,7 @@ execute as @a[scores={bannerplz=1}] run function nincodedo:triggers/givebannerfo
 execute as @a[tag=!triggerbannerenabled] run scoreboard players enable @s bannerplz
 execute as @a[tag=!triggerbannerenabled] run loot give @s loot nincodedo:docs/faq_book
 execute as @a[tag=!triggerbannerenabled] run tag @s add triggerbannerenabled
+execute as @a[tag=holdbonemeal] at @s anchored eyes if block ^ ^ ^1 #minecraft:small_flowers run scoreboard players set @s lookingatsmallflower 1
+execute as @a[tag=holdbonemeal] at @s anchored eyes if block ^ ^ ^2 #minecraft:small_flowers run scoreboard players set @s lookingatsmallflower 1
+execute as @a[tag=holdbonemeal] at @s anchored eyes if block ^ ^ ^3 #minecraft:small_flowers run scoreboard players set @s lookingatsmallflower 1
+execute as @a[tag=holdbonemeal] at @s anchored eyes unless block ^ ^ ^1 #minecraft:small_flowers unless block ^ ^ ^2 #minecraft:small_flowers unless block ^ ^ ^3 #minecraft:small_flowers run scoreboard players set @s lookingatsmallflower 0

--- a/datapacks/ocw-stuff/data/nincodedo/functions/tick.mcfunction
+++ b/datapacks/ocw-stuff/data/nincodedo/functions/tick.mcfunction
@@ -6,3 +6,8 @@ execute as @a[tag=holdbonemeal] at @s anchored eyes if block ^ ^ ^1 #minecraft:s
 execute as @a[tag=holdbonemeal] at @s anchored eyes if block ^ ^ ^2 #minecraft:small_flowers run scoreboard players set @s lookingatsmallflower 1
 execute as @a[tag=holdbonemeal] at @s anchored eyes if block ^ ^ ^3 #minecraft:small_flowers run scoreboard players set @s lookingatsmallflower 1
 execute as @a[tag=holdbonemeal] at @s anchored eyes unless block ^ ^ ^1 #minecraft:small_flowers unless block ^ ^ ^2 #minecraft:small_flowers unless block ^ ^ ^3 #minecraft:small_flowers run scoreboard players set @s lookingatsmallflower 0
+
+execute as @a[tag=holdbonemeal] at @s anchored eyes if block ^ ^ ^1 minecraft:sugar_cane run scoreboard players set @s lookingatsugarcane 1
+execute as @a[tag=holdbonemeal] at @s anchored eyes if block ^ ^ ^2 minecraft:sugar_cane run scoreboard players set @s lookingatsugarcane 1
+execute as @a[tag=holdbonemeal] at @s anchored eyes if block ^ ^ ^3 minecraft:sugar_cane run scoreboard players set @s lookingatsugarcane 1
+execute as @a[tag=holdbonemeal] at @s anchored eyes unless block ^ ^ ^1 minecraft:sugar_cane unless block ^ ^ ^2 minecraft:sugar_cane unless block ^ ^ ^3 minecraft:sugar_cane run scoreboard players set @s lookingatsugarcane 0


### PR DESCRIPTION
Players can use bone meal on small flowers to get more of the same flower, and grow sugar cane. A suggestion from Try4se!