### PR TITLE
Player gift scammed advancements

### DIFF
--- a/datapacks/ocw-stuff/data/nincodedo/advancements/player_gifts/scammed/fake_metal_link.json
+++ b/datapacks/ocw-stuff/data/nincodedo/advancements/player_gifts/scammed/fake_metal_link.json
@@ -1,0 +1,44 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:thrown_item_picked_up_by_entity",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:reference",
+              "name": "nincodedo:isentitymetallink"
+            }
+          }
+        ],
+        "entity": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "type": "minecraft:player"
+            }
+          },
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:reference",
+              "name": "nincodedo:isentitymetallink"
+            }
+          },
+          {
+            "condition": "minecraft:reference",
+            "name": "nincodedo:is/entity/wearing/metal_link_player_head"
+          }
+        ],
+        "item": {
+          "items": [
+            "minecraft:cactus",
+            "minecraft:green_dye"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/advancements/player_gifts/scammed/fake_nincodedo.json
+++ b/datapacks/ocw-stuff/data/nincodedo/advancements/player_gifts/scammed/fake_nincodedo.json
@@ -1,0 +1,44 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:thrown_item_picked_up_by_entity",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:reference",
+              "name": "nincodedo:isentitynincodedo"
+            }
+          }
+        ],
+        "entity": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "type": "minecraft:player"
+            }
+          },
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:reference",
+              "name": "nincodedo:isentitynincodedo"
+            }
+          },
+          {
+            "condition": "minecraft:reference",
+            "name": "nincodedo:is/entity/wearing/nincodedo_player_head"
+          }
+        ],
+        "item": {
+          "items": [
+            "minecraft:blue_dye",
+            "minecraft:lapis_lazuli"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/advancements/player_gifts/scammed/fake_novastardust.json
+++ b/datapacks/ocw-stuff/data/nincodedo/advancements/player_gifts/scammed/fake_novastardust.json
@@ -1,0 +1,44 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:thrown_item_picked_up_by_entity",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:reference",
+              "name": "nincodedo:isentitynovastardust"
+            }
+          }
+        ],
+        "entity": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "type": "minecraft:player"
+            }
+          },
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:reference",
+              "name": "nincodedo:isentitynovastardust"
+            }
+          },
+          {
+            "condition": "minecraft:reference",
+            "name": "nincodedo:is/entity/wearing/novastardust_player_head"
+          }
+        ],
+        "item": {
+          "items": [
+            "minecraft:bone_block",
+            "minecraft:bone"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/advancements/player_gifts/scammed/fake_try4se.json
+++ b/datapacks/ocw-stuff/data/nincodedo/advancements/player_gifts/scammed/fake_try4se.json
@@ -1,0 +1,59 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:thrown_item_picked_up_by_entity",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:reference",
+              "name": "nincodedo:isentitytry4se"
+            }
+          }
+        ],
+        "entity": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "type": "minecraft:player"
+            }
+          },
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:reference",
+              "name": "nincodedo:isentitytry4se"
+            }
+          },
+          {
+            "condition": "minecraft:reference",
+            "name": "nincodedo:is/entity/wearing/try4se_player_head"
+          }
+        ],
+        "item": {
+          "items": [
+            "minecraft:black_wool",
+            "minecraft:blue_wool",
+            "minecraft:brown_wool",
+            "minecraft:cyan_wool",
+            "minecraft:gray_wool",
+            "minecraft:green_wool",
+            "minecraft:light_blue_wool",
+            "minecraft:light_gray_wool",
+            "minecraft:lime_wool",
+            "minecraft:magenta_wool",
+            "minecraft:orange_wool",
+            "minecraft:pink_wool",
+            "minecraft:purple_wool",
+            "minecraft:red_wool",
+            "minecraft:white_wool",
+            "minecraft:yellow_wool",
+            "minecraft:lead"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/advancements/player_gifts/scammed/fake_tunasz.json
+++ b/datapacks/ocw-stuff/data/nincodedo/advancements/player_gifts/scammed/fake_tunasz.json
@@ -1,0 +1,44 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:thrown_item_picked_up_by_entity",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:reference",
+              "name": "nincodedo:isentitytunasz"
+            }
+          }
+        ],
+        "entity": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "type": "minecraft:player"
+            }
+          },
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:reference",
+              "name": "nincodedo:isentitytunasz"
+            }
+          },
+          {
+            "condition": "minecraft:reference",
+            "name": "nincodedo:is/entity/wearing/tunasz_player_head"
+          }
+        ],
+        "item": {
+          "items": [
+            "minecraft:torch"
+          ],
+          "count": 64
+        }
+      }
+    }
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/advancements/player_gifts/scammed/fake_undeadzeratul.json
+++ b/datapacks/ocw-stuff/data/nincodedo/advancements/player_gifts/scammed/fake_undeadzeratul.json
@@ -1,0 +1,43 @@
+{
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:thrown_item_picked_up_by_entity",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:reference",
+              "name": "nincodedo:isentityundeadzeratul"
+            }
+          }
+        ],
+        "entity": [
+          {
+            "condition": "minecraft:entity_properties",
+            "entity": "this",
+            "predicate": {
+              "type": "minecraft:player"
+            }
+          },
+          {
+            "condition": "minecraft:inverted",
+            "term": {
+              "condition": "minecraft:reference",
+              "name": "nincodedo:isentityundeadzeratul"
+            }
+          },
+          {
+            "condition": "minecraft:reference",
+            "name": "nincodedo:is/entity/wearing/undeadzeratul_player_head"
+          }
+        ],
+        "item": {
+          "items": [
+            "minecraft:scaffolding"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/advancements/player_gifts/scammed/got_scammed.json
+++ b/datapacks/ocw-stuff/data/nincodedo/advancements/player_gifts/scammed/got_scammed.json
@@ -1,0 +1,101 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:player_head",
+      "nbt": "{SkullOwner:{Id:[I;449435050,1190088049,-1334360732,942410307],Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNGFlZTZiYjM3Y2JmYzkyYjBkODZkYjVhZGE0NzkwYzY0ZmY0NDY4ZDY4Yjg0OTQyZmRlMDQ0MDVlOGVmNTMzMyJ9fX0=\"}]}}}"
+    },
+    "title": "SCAMMED",
+    "description": "You've been smackledorfed!",
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": true
+  },
+  "parent": "nincodedo:player_gifts/root",
+  "criteria": {
+    "requirement": {
+      "trigger": "minecraft:location",
+      "conditions": {
+        "player": [
+          {
+            "condition": "minecraft:alternative",
+            "terms": [
+              {
+                "condition": "minecraft:entity_properties",
+                "entity": "this",
+                "predicate": {
+                  "type_specific": {
+                    "type": "player",
+                    "advancements": {
+                      "nincodedo:player_gifts/scammed/fake_metal_link": true
+                    }
+                  }
+                }
+              },
+              {
+                "condition": "minecraft:entity_properties",
+                "entity": "this",
+                "predicate": {
+                  "type_specific": {
+                    "type": "player",
+                    "advancements": {
+                      "nincodedo:player_gifts/scammed/fake_nincodedo": true
+                    }
+                  }
+                }
+              },
+              {
+                "condition": "minecraft:entity_properties",
+                "entity": "this",
+                "predicate": {
+                  "type_specific": {
+                    "type": "player",
+                    "advancements": {
+                      "nincodedo:player_gifts/scammed/fake_novastardust": true
+                    }
+                  }
+                }
+              },
+              {
+                "condition": "minecraft:entity_properties",
+                "entity": "this",
+                "predicate": {
+                  "type_specific": {
+                    "type": "player",
+                    "advancements": {
+                      "nincodedo:player_gifts/scammed/fake_try4se": true
+                    }
+                  }
+                }
+              },
+              {
+                "condition": "minecraft:entity_properties",
+                "entity": "this",
+                "predicate": {
+                  "type_specific": {
+                    "type": "player",
+                    "advancements": {
+                      "nincodedo:player_gifts/scammed/fake_tunasz": true
+                    }
+                  }
+                }
+              },
+              {
+                "condition": "minecraft:entity_properties",
+                "entity": "this",
+                "predicate": {
+                  "type_specific": {
+                    "type": "player",
+                    "advancements": {
+                      "nincodedo:player_gifts/scammed/fake_undeadzeratul": true
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/advancements/rewards/player_gifts/scammed/got_scammed.json
+++ b/datapacks/ocw-stuff/data/nincodedo/advancements/rewards/player_gifts/scammed/got_scammed.json
@@ -1,0 +1,23 @@
+{
+  "display": {
+    "icon": {
+      "item": "minecraft:player_head",
+      "nbt": "{SkullOwner:{Id:[I;449435050,1190088049,-1334360732,942410307],Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNGFlZTZiYjM3Y2JmYzkyYjBkODZkYjVhZGE0NzkwYzY0ZmY0NDY4ZDY4Yjg0OTQyZmRlMDQ0MDVlOGVmNTMzMyJ9fX0=\"}]}}}"
+    },
+    "title": "SCAMMED",
+    "description": "You've been smackledorfed!",
+    "frame": "task",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true
+  },
+  "parent": "nincodedo:rewards/player_gifts/root",
+  "criteria": {
+    "nop": {
+      "trigger": "minecraft:impossible"
+    }
+  },
+  "rewards": {
+    "function": "nincodedo:rewards/random_player_head"
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/functions/rewards/random_player_head.mcfunction
+++ b/datapacks/ocw-stuff/data/nincodedo/functions/rewards/random_player_head.mcfunction
@@ -1,0 +1,3 @@
+tag @s add me
+execute at @s as @r[tag=!me] run loot give @p loot nincodedo:player_head
+tag @s remove me

--- a/datapacks/ocw-stuff/data/nincodedo/loot_tables/player_head.json
+++ b/datapacks/ocw-stuff/data/nincodedo/loot_tables/player_head.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:selector",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:player_head",
+          "functions": [
+            {
+              "function": "minecraft:fill_player_head",
+              "entity": "this"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/datapacks/ocw-stuff/data/nincodedo/predicates/is/entity/wearing/metal_link_player_head.json
+++ b/datapacks/ocw-stuff/data/nincodedo/predicates/is/entity/wearing/metal_link_player_head.json
@@ -1,0 +1,14 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "head": {
+        "items": [
+          "minecraft:player_head"
+        ],
+        "nbt": "{SkullOwner: {Id: [I; -2145763756, 845696088, -1763149853, 991948061]}}"
+      }
+    }
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/predicates/is/entity/wearing/nincodedo_player_head.json
+++ b/datapacks/ocw-stuff/data/nincodedo/predicates/is/entity/wearing/nincodedo_player_head.json
@@ -1,0 +1,14 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "head": {
+        "items": [
+          "minecraft:player_head"
+        ],
+        "nbt": "{SkullOwner: {Id: [I; -584958556, -1931130868, -1889383291, 1877270125]}}"
+      }
+    }
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/predicates/is/entity/wearing/novastardust_player_head.json
+++ b/datapacks/ocw-stuff/data/nincodedo/predicates/is/entity/wearing/novastardust_player_head.json
@@ -1,0 +1,14 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "head": {
+        "items": [
+          "minecraft:player_head"
+        ],
+        "nbt": "{SkullOwner: {Id: [I;-1414250168,1208962941,-1850872904,-2001836343]}}"
+      }
+    }
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/predicates/is/entity/wearing/try4se_player_head.json
+++ b/datapacks/ocw-stuff/data/nincodedo/predicates/is/entity/wearing/try4se_player_head.json
@@ -1,0 +1,14 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "head": {
+        "items": [
+          "minecraft:player_head"
+        ],
+        "nbt": "{SkullOwner: {Id: [I; 769093600, -1959968053, -1514102921, 1462075729]}}"
+      }
+    }
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/predicates/is/entity/wearing/tunasz_player_head.json
+++ b/datapacks/ocw-stuff/data/nincodedo/predicates/is/entity/wearing/tunasz_player_head.json
@@ -1,0 +1,14 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "head": {
+        "items": [
+          "minecraft:player_head"
+        ],
+        "nbt": "{SkullOwner: {Id: [I;-1134297099,228347247,-1929822783,-611013429]}}"
+      }
+    }
+  }
+}

--- a/datapacks/ocw-stuff/data/nincodedo/predicates/is/entity/wearing/undeadzeratul_player_head.json
+++ b/datapacks/ocw-stuff/data/nincodedo/predicates/is/entity/wearing/undeadzeratul_player_head.json
@@ -1,0 +1,14 @@
+{
+  "condition": "minecraft:entity_properties",
+  "entity": "this",
+  "predicate": {
+    "equipment": {
+      "head": {
+        "items": [
+          "minecraft:player_head"
+        ],
+        "nbt": "{SkullOwner: {Id: [I; -223431324, 1556303093, -1412706370, -1585750994]}}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
If you attempt to give someone their specific player gift, but it is not the player and they are wearing the correct head to fool you to give them that player gift, you now get a "SCAMMED" advancement. This gives you a random player head in the next attempt.